### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Pod/Strip.pm6
+++ b/lib/Pod/Strip.pm6
@@ -16,7 +16,7 @@ Pod::Strip
 
 =head2 module Pod::Strip;
 
-module Pod::Strip;
+unit module Pod::Strip;
 
 =head3 Subroutines
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
