### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/test-out.txt
+++ b/t/test-out.txt
@@ -1,5 +1,5 @@
 use v6;
-BEGIN { @*INC.unshift: 'blib/lib' }
+use lib 'blib/lib';
 
 use Test;
 use Pod::Strip;

--- a/t/test.t
+++ b/t/test.t
@@ -1,5 +1,5 @@
 use v6;
-BEGIN { @*INC.unshift: 'blib/lib' }
+use lib 'blib/lib';
 
 use Test;
 use Pod::Strip;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.
