### PR TITLE
Fix problems due to bitrot

### DIFF
--- a/lib/Pod/Strip.pm6
+++ b/lib/Pod/Strip.pm6
@@ -21,7 +21,7 @@ unit module Pod::Strip;
 =head3 Subroutines
 
 #| Replace Pod lines with empty lines.
-sub _pod-strip(@in is rw, Str :$in-block? = '') {
+sub _pod-strip(@in, Str :$in-block? = '') {
     my @out;
     my $in-para = False;
     while @in.elems {

--- a/t/test-out.txt
+++ b/t/test-out.txt
@@ -1,5 +1,4 @@
 use v6;
-BEGIN { @*INC.unshift: 'blib/lib' }
 
 use Test;
 use Pod::Strip;

--- a/t/test.t
+++ b/t/test.t
@@ -1,5 +1,4 @@
 use v6;
-BEGIN { @*INC.unshift: 'blib/lib' }
 
 use Test;
 use Pod::Strip;


### PR DESCRIPTION
Because of today's Squashathon there was a [ticket about your module failing](https://github.com/perl6/ecosystem-unbitrot/issues/90).  I looked at the problem, and it appears all of that was caused by subtle (or not so subtle) changes to Rakudo Perl 6.  This Pull Request should fix all of the issues and make testing clean again.